### PR TITLE
コンテナ化対応（Apache+PHP）

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteCond $1 !^(index\.php|images|robots\.txt)
+RewriteRule ^(.*)$ /index.php/$1 [L]

--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,0 @@
-RewriteEngine on
-RewriteCond $1 !^(index\.php|images|robots\.txt)
-RewriteRule ^(.*)$ /index.php/$1 [L]

--- a/.htaccess
+++ b/.htaccess
@@ -1,3 +1,5 @@
+<IfModule mod_rewrite.c>
 RewriteEngine on
 RewriteCond $1 !^(index\.php|images|robots\.txt)
 RewriteRule ^(.*)$ /index.php/$1 [L]
+</IfModule>

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN git checkout docker-test
 # Change DocumentRoot
 
 ENV APACHE_DOCUMENT_ROOT /var/www/apps/test-codeigniter
+ENV APACHE_LOG_DIR /var/log/apache2
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,8 @@ RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf
 
 RUN sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
 
-EXPOSE 8000:80
+# mod_rewrite on
+RUN a2enmod rewrite
+
+EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# base image
+FROM php:5.6-apache
+
+# FOR DEV
+RUN apt-get update
+RUN apt-get install -y vim
+
+# get source
+RUN apt-get install -y git
+
+WORKDIR /var/www/apps
+RUN git clone https://github.com/maeno-c/test-codeigniter
+WORKDIR /var/www/apps/test-codeigniter
+
+# TEMP
+RUN git checkout docker-test
+
+
+# Change DocumentRoot
+
+ENV APACHE_DOCUMENT_ROOT /var/www/apps/test-codeigniter
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+RUN sed -i "s/AllowOverride None/AllowOverride All/g" /etc/apache2/apache2.conf
+
+EXPOSE 8000:80
+

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -61,7 +61,7 @@ $db['default']['cachedir'] = '';
 $db['default']['char_set'] = 'utf8';
 $db['default']['dbcollat'] = 'utf8_general_ci';
 $db['default']['swap_pre'] = '';
-$db['default']['autoinit'] = TRUE;
+$db['default']['autoinit'] = FALSE;
 $db['default']['stricton'] = FALSE;
 
 


### PR DESCRIPTION
## 内容
DockerHub公式のphp:5.6-apacheイメージを使ってアプリへのアクセスまで対応する

（Postgresは別コンテナを用意する）

## TODO
- [ ] `.htaccess`ファイルがあることで、アクセスがうまくいかない（500で返ってくる）ので対応する（`.htaccess`がなければアクセスできるが、そうするとroutingがうまくいかない）
- [ ] そもそもコンテナ側のApacheのログも取得できていない
- [ ] DB接続先/base_urlをENVで対応する
